### PR TITLE
Ignore files for better collaboration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.tfstate
+*.tfstate.backup
+*.tfvars
+.terraform


### PR DESCRIPTION
This PR adds a .gitignore file to ignore certain Terraform files in the repository (Terraform state and state backup files as well as Terraform variable files). This will make it easier for multiple users to collaborate on this repository.