### PR TITLE
Fix issues with multiple copies of the environment

### DIFF
--- a/hosts/ec2.ini
+++ b/hosts/ec2.ini
@@ -109,7 +109,7 @@ all_elasticache_nodes = False
 # will be written to this directory:
 #   - ansible-ec2.cache
 #   - ansible-ec2.index
-cache_path = ~/.ansible/tmp
+cache_path = .ansible/tmp
 
 # The number of seconds a cache file is considered valid. After this many
 # seconds, a new API call will be made, and the cache file will be updated.
@@ -165,6 +165,9 @@ group_by_elasticache_replication_group = True
 # allows the use of multiple conditions to filter down, for example by
 # environment and type of host.
 stack_filters = False
+
+# Retrieve only instances in specified VPC ID
+instance_filters = vpc-id=<value>
 
 # Retrieve only instances with (key=value) env=staging tag
 # instance_filters = tag:env=staging


### PR DESCRIPTION
I didn't account for the `ec2.py` script picking up multiple copies of the environment, so this PR fixes that by filtering instances according to VPC ID. After creating a new environment with `terraform apply`, use the VPC ID of the newly-created VPC in the `ec2.ini` file (search for "vpc-id" to see where to put it) to ensure that Ansible sees _only_ the instance in that specific environment.